### PR TITLE
Fix jungle tasks

### DIFF
--- a/lib/capistrano/tasks/jungle.rake
+++ b/lib/capistrano/tasks/jungle.rake
@@ -72,7 +72,7 @@ namespace :puma do
       desc "#{command} puma"
       task command do
         on roles(fetch(:puma_role)) do
-          sudo "service puma #{command} #{current_path}"
+          sudo "service puma #{command} app=#{current_path}"
         end
       end
     end


### PR DESCRIPTION
Fix error `Env must be KEY=VALUE pairs` produced by `service puma #{command} #{current_path}`